### PR TITLE
Add MTA 'msmtp' as alternative to postfix.sendmail

### DIFF
--- a/default.env
+++ b/default.env
@@ -37,6 +37,7 @@ MYSQL_USER=asterisk
 
 ## specify DNS name or IP address for the SMTP RelayHost (default: none)
 #SMTP_RELAYHOST=[smtp.example.com]:587
+#SMTP_RELAYHOST_PORT=25
 #SMTP_RELAYHOST_USERNAME=yourusername
 #SMTP_RELAYHOST_PASSWORD=yoursecurepassword
 #SMTP_STARTTLS=true
@@ -194,6 +195,7 @@ APP_PORT_ZABBIX=10050
 
 ### Container Services
 #POSTFIX_ENABLED=true
+#MSMTP_ENABLED=true
 CRON_ENABLED=true
 HTTPD_ENABLED=true
 IZPBX_ENABLED=true

--- a/izpbx-asterisk/Dockerfile
+++ b/izpbx-asterisk/Dockerfile
@@ -56,6 +56,7 @@ ARG ZABBIX_TEMPLATE_VER=main
 
 ## https://github.com/irontec/sngrep/releases
 ARG SNGREP_VER=1.6.0
+ARG SNGREP_XTRA_BUILDCONFIG=""
 
 ### define variables for later container usage
 ENV ASTERISK_VER=${ASTERISK_VER}
@@ -649,7 +650,7 @@ RUN set -xe && \
   curl -fSL --connect-timeout 30 https://github.com/irontec/sngrep/archive/v${SNGREP_VER}.tar.gz | tar xz --strip 1 -C sngrep && \
   cd sngrep && \
   ./bootstrap.sh && \
-  ./configure --prefix=/usr && \
+  ./configure --prefix=/usr ${SNGREP_XTRA_BUILDCONFIG} && \
   make && \
   make install && \
   ldconfig && \

--- a/izpbx-asterisk/Dockerfile
+++ b/izpbx-asterisk/Dockerfile
@@ -78,6 +78,9 @@ ENV APP_GRP               "asterisk"
 ## development debug mode (don't delete development and build dependencies on filesystem)
 ARG APP_DEBUG=0
 
+## install ad hoc additional packages as defined via --build-arg next to regular dependencies
+ARG APP_INSTALL_EXTRA=""
+
 ### STEP 1: INSTALL BASE PACKAGES
 RUN set -xe && \
   ## import system information vars
@@ -252,7 +255,7 @@ RUN set -xe && \
   ## upgrade the system
   dnf upgrade ${DNF_OPTS} && \
   ## install mandatory packages
-  dnf install ${DNF_OPTS} ${APP_INSTALL_DEPS} ${APP_INSTALL_DEPS_EXTRA} \
+  dnf install ${DNF_OPTS} ${APP_INSTALL_DEPS} ${APP_INSTALL_DEPS_EXTRA} ${APP_INSTALL_EXTRA} \
   && \
   if [[ "$RHEL_MINIMAL" = "false" ]]; then \
     dnf mark install ${APP_INSTALL_DEPS} ${APP_INSTALL_DEPS_EXTRA} \

--- a/izpbx-asterisk/rootfs/entrypoint-hooks.sh
+++ b/izpbx-asterisk/rootfs/entrypoint-hooks.sh
@@ -1548,6 +1548,38 @@ cfgBashEnv() {
   echo'
 }
 
+cfgService_msmtp() {
+
+    echo "=> Setting up msmptp as default sendmail replacement"
+
+    if [ ! -r ~asterisk/.msmtprc ] ; then
+    cat <<EOF > "~asterisk/.msmtprc"
+# Set default values for all following accounts.
+defaults
+auth           off
+tls            off
+#tls_trust_file /etc/ssl/certs/ca-certificates.crt
+logfile        ~asterisk/msmtp.log
+
+# localmta
+account        localmta
+host           ${SMTP_RELAYHOST}
+port           ${SMTP_RELAYHOST_PORT}
+tls_starttls   off
+from           ${SMTP_MAIL_FROM}
+user           ${SMTP_RELAYHOST_USERNAME}
+password       ${SMTP_RELAYHOST_PASSWORD}
+
+# Set a default account
+account default : localmta
+
+EOF
+  fi
+
+  alternatives --set mta /usr/bin/msmtp
+
+}
+
 runHooks() {
   # configure supervisord
   echo "--> fixing supervisord config file..."
@@ -1629,6 +1661,7 @@ runHooks() {
   # enable/disable and configure services
   #chkService SYSLOG_ENABLED
   chkService POSTFIX_ENABLED
+  chkService MSMTP_ENABLED
   chkService CRON_ENABLED
   chkService FAIL2BAN_ENABLED
   chkService HTTPD_ENABLED

--- a/izpbx-asterisk/rootfs/entrypoint-hooks.sh
+++ b/izpbx-asterisk/rootfs/entrypoint-hooks.sh
@@ -1559,12 +1559,12 @@ cfgService_msmtp() {
           echo "   ...Automatic install failed. Make sure to install the package manually before retrying. Abort."
           exit 0
       }
+    fi
 
     # check if configuration file already exists in $APP_USR home directory, if not, create default configuration
     USR_HOME="$(getent passwd "$APP_USR" | cut -d: -f6)"
     if [ ! -r "${USR_HOME}/.msmtprc" ] ; then
-    cat <<EOF > "${USR_HOME}/.msmtprc"
-# Set default values for all following accounts.
+    	echo "# Set default values for all following accounts.
 defaults
 auth           off
 tls            off
@@ -1582,11 +1582,12 @@ password       ${SMTP_RELAYHOST_PASSWORD}
 
 # Set a default account
 account default : local-mta
-EOF
-  fi
+" > "${USR_HOME}/.msmtprc"
+  fi ;
 
   # set alternative for mta to 'msmtp' thereby updating symlinks in rootfs
   alternatives --set mta /usr/bin/msmtp
+
 }
 
 runHooks() {


### PR DESCRIPTION
@ugoviti: 
**Feature branch makes 'msmtp' available as an additional MTA service alternative**
particularly useful in cases when there is already a mailserver instance configured and running on the container  host system and ixPBX is configured for network_mode: host 
