### PR TITLE
Experimental newfeature autoban

### DIFF
--- a/izpbx-asterisk/rootfs/entrypoint-hooks.sh
+++ b/izpbx-asterisk/rootfs/entrypoint-hooks.sh
@@ -555,6 +555,101 @@ cfgService_fail2ban() {
   set | grep ^"FAIL2BAN_" | sed -e 's/^FAIL2BAN_//' | sed -e 's/_/ /' | iniParser "/etc/fail2ban/jail.d/99-local.conf"
 }
 
+## autoban service
+cfgService_autoban() {
+  
+  echo "--> Configuring autoban settings..."
+
+  ## Required ENV Settings
+  #ENV DOCKER_NFT_DIR="/etc/nftables"
+  #ENV DOCKER_NFT_FILE="autoban.nft"
+  #ENV AUTOBAN_PWD=""
+  #ENV AUTOBAN_NFT_PORT_RULES
+
+  AUTOBAN_NFT_PORT_RULES=${AUTOBAN_NFT_PORT_RULES:=""}
+
+  local autoban_dir="/usr/local/share/autoban"
+  local autoban_seed_conf_file="${autoban_dir}/autoban.conf"
+  local autoban_seed_nft_file="${autoban_dir}/autoban.nft"
+  local autoban_conf_file="/etc/asterisk/autoban.conf"
+  local ami_conf_file="/etc/asterisk/manager_custom.conf"
+  local autoban_nft_table="autoban"
+
+  #fix permissions
+  chmod 755 ${autoban_dir}/autoband.php
+  chmod 755 ${autoban_dir}/autoban.php
+  
+  #create symlinks in searchpath
+  ln -sf ${autoban_dir}/autoband.php /usr/local/sbin/autoband
+  ln -sf ${autoban_dir}/autoban.php /usr/local/bin/autoban
+  
+  #seed config if not yet existant
+  if [ ! -s "${autoban_conf_file}" ]; then
+    
+    #generate random password if empty / not set
+    [ -z ${AUTOBAN_PWD} ] &&  AUTOBAN_PWD=$(date +%s | sha256sum | base64 | head -c 32)
+    
+    cat <<EOF >"${autoban_conf_file}"
+;
+; autoban.conf
+;
+; This file hold user customization of the AutoBan intrusion detection and
+; prevention system. This is a php ini file. Luckily its syntax is similar to
+; other asterisk conf files. "yes" and "no" have to be within quotation marks
+; otherwise they will be interpreted as Boolean.
+;
+
+[asmanager]
+server     = 127.0.0.1
+port       = 5038
+username   = autoban
+secret     = ${AUTOBAN_PWD}
+
+[autoban]
+maxcount   = 10
+watchtime  = 20m
+jailtime   = 20m
+repeatmult = 6
+EOF
+    
+    #purge [autoban] section if any and  rewrite
+    [ -s ${ami_conf_file} ] && sed -i '/^\[autoban]/,/^\[/{/^\[autoban\]/d; /^\[/!d}' ${ami_conf_file}
+    cat <<EOF >>${ami_conf_file}
+[autoban]
+secret   = ${AUTOBAN_PWD}
+permit   = 127.0.0.1/255.255.255.255
+read     = security
+write    =
+EOF
+
+  fi
+  #
+  # If DOCKER_NFT_FILE is empty or is missing
+  # initialize it with files from DOCKER_SEED_NFT_DIR.
+  #
+
+  #nft_file=$DOCKER_NFT_DIR/$DOCKER_NFT_FILE
+  nft_file="/etc/nftables/autoban.nft"
+
+  if [ ! -s ${nft_file} ]; then
+    cp ${autoban_seed_nft_file} "/etc/nftables/"
+    sed -i "s/EXTRA_NFT_PORT_RULES/${AUTOBAN_NFT_PORT_RULES}/" ${nft_file}
+  fi
+
+  #
+  # If nft_file exists have NFT import it
+  #
+
+  if [ -f ${nft_file} ]; then
+    echo "Importing $nft_file."
+    if nft delete table ${autoban_nft_table} 2>/dev/null; then
+      echo  "nft table ${autoban_nft_table} was overwritten"
+    fi
+    nft -f ${nft_file}
+  fi
+
+}
+
 ## apache service
 cfgService_httpd() {
 
@@ -1654,6 +1749,7 @@ runHooks() {
   chkService HTTPD_ENABLED
   chkService ASTERISK_ENABLED
   chkService IZPBX_ENABLED
+  chkService AUTOBAN_ENABLED
   chkService ZABBIX_ENABLED
   chkService FOP2_ENABLED
   chkService NTP_ENABLED

--- a/izpbx-asterisk/rootfs/etc/supervisord.d/autoban.ini
+++ b/izpbx-asterisk/rootfs/etc/supervisord.d/autoban.ini
@@ -1,0 +1,16 @@
+[program:autoban]
+command=/usr/local/sbin/autoband
+autostart=false
+autorestart=true
+startretries=3
+startsecs=30
+priority=1500
+user=root
+killasgroup=true
+stopasgroup=true
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
+stdout_events_enabled = true
+stderr_events_enabled = true

--- a/izpbx-asterisk/rootfs/usr/local/sbin/startautoban
+++ b/izpbx-asterisk/rootfs/usr/local/sbin/startautoban
@@ -1,0 +1,112 @@
+#! /usr/bin/env bash
+
+cfgService_autoban() {
+  
+  echo "--> Configuring autoban settings..."
+
+
+  ## USED ENV Settings
+  #ENV DOCKER_NFT_DIR="/etc/nftables"
+  #ENV DOCKER_NFT_FILE="autoban.nft"
+  #ENV AUTOBAN_PWD=""
+  #ENV AUTOBAN_NFT_PORT_RULES
+  AUTOBAN_NFT_PORT_RULES=${AUTOBAN_NFT_PORT_RULES:=""}
+
+  local autoban_dir="/usr/local/share/autoban"
+  local autoban_conf_file="/etc/asterisk/autoban.conf"
+  local autoban_nft_table="autoban"
+  local autoban_nft_file="${DOCKER_NFT_DIR:="/etc/nftables"}/${DOCKER_NFT_FILE:="autoban.nft"}"
+  local ami_conf_file="/etc/asterisk/manager_custom.conf"
+  
+  # always (re)create autoban and asterisk manager config
+  # intended to avoid problems if an old autoban config file is restored by  FreePBX restore without nmachting manager config 
+
+  [ -z ${AUTOBAN_PWD} ] &&  AUTOBAN_PWD="$(date +%s | sha256sum | base64 | head -c 32)"
+  
+   cat >"${autoban_conf_file}" <<EOF
+;
+; THIS FILE IS AUTOMATICALLY (RE)GENERATED AND MAY BE OVERWRITTEN ANY TIME.
+; DO NOT MODIFY !!!
+; seetings can be changed via according autoban_... environment variables
+;
+; autoban.conf
+;
+; This file holds user customization of the AutoBan intrusion detection and
+; prevention system. This is a php ini file. Luckily its syntax is similar to
+; other asterisk conf files. "yes" and "no" have to be within quotation marks
+; otherwise they will be interpreted as Boolean.
+;
+
+[asmanager]
+server     = 127.0.0.1
+port       = 5038
+username   = autoban
+secret     = ${AUTOBAN_PWD}
+
+[autoban]
+maxcount   = 10
+watchtime  = 20m
+jailtime   = 20m
+repeatmult = 6
+EOF
+
+  # purge [autoban] section in manager config file if any and  rewrite
+  [ -s ${ami_conf_file} ] && \
+    sed -i '/^\[autoban]/,/^\[/{/^\[autoban\]/d; /^\[/!d}' ${ami_conf_file}
+
+  cat >>${ami_conf_file} <<EOF 
+[autoban]
+secret   = ${AUTOBAN_PWD}
+permit   = 127.0.0.1/255.255.255.255
+read     = security
+write    =
+EOF
+
+  # (re)create ${autoban_nft_file} from template if missing
+  [ ! -s ${autoban_nft_file} ] && \
+    cat >${autoban_nft_file} <<EOF
+#!/usr/sbin/nft -f
+#
+
+table ip autoban {
+	set watch {
+		type ipv4_addr
+		flags timeout
+	}
+	set jail {
+		type ipv4_addr
+		flags timeout
+	}
+	set parole {
+		type ipv4_addr
+		flags timeout
+	}
+	set blacklist {
+		type ipv4_addr
+	}
+	set whitelist {
+		type ipv4_addr
+	}
+
+	chain incoming {
+		type filter hook input priority security; policy accept;
+		ip saddr @whitelist accept
+		ip saddr @blacklist ${AUTOBAN_NFT_PORT_RULES} drop
+		ip saddr @jail ${AUTOBAN_NFT_PORT_RULES} drop
+	}
+}
+EOF
+
+  # import ${autoban_nft_file} into nftables
+  [ -s ${autoban_nft_file} ] && \
+    nft -f ${autoban_nft_file}
+
+  #fix permissions and create symlinks in searchpath
+  chmod 755 ${autoban_dir}/autoband.php
+  ln -sf ${autoban_dir}/autoband.php /usr/local/sbin/autoband
+  chmod 755 ${autoban_dir}/autoban.php
+  ln -sf ${autoban_dir}/autoban.php /usr/local/bin/autoban
+
+}
+
+cfgService_autoban

--- a/izpbx-asterisk/rootfs/usr/local/share/autoban/ami.class.inc
+++ b/izpbx-asterisk/rootfs/usr/local/share/autoban/ami.class.inc
@@ -1,0 +1,1249 @@
+<?php
+/**
+ * Copyright (c) 2004 - 2010 Finlay Beaton <ofbeaton@gmail.com> and others, PHPAGI (pre-fork)
+ * All Rights Reserved.
+ *
+ * This software is released under the terms of the GNU Lesser General Public License v2.1
+ *  A copy of which is available from http://www.gnu.org/copyleft/lesser.html
+ */
+
+namespace PHPAMI;
+
+/**
+ * Asterisk Manager class
+ *
+ * @link    http://www.voip-info.org/wiki-Asterisk+config+manager.conf
+ * @link    http://www.voip-info.org/wiki-Asterisk+manager+API
+ * @example examples/sip_show_peer.php Get information about a sip peer
+ */
+class Ami
+{
+    /**
+     * Location of the asterisk directory.
+     */
+    const AST_CONFIG_DIR = '/etc/asterisk/';
+
+    /**
+     * Default configuration file for PHPAMI, in the asterisk directory.
+     */
+    const DEFAULT_PHPAMI_CONFIG = '/etc/asterisk/phpami.conf';
+
+    /**
+     * Default configuration file for PHPAGI, in the asterisk directory.
+     *
+     * Included for backwards compatibility with PHPAGI library.
+     */
+    const DEFAULT_PHPAGI_CONFIG = '/etc/asterisk/phpagi.conf';
+
+    /**
+     * Log level.
+     */
+    const LOG_FATAL = 0;
+
+    /**
+     * Log level.
+     */
+    const LOG_ERROR = 1;
+
+    /**
+     * Log level.
+     */
+    const LOG_WARN = 2;
+
+    /**
+     * Log level.
+     */
+    const LOG_INFO = 3;
+
+    /**
+     * Log level.
+     */
+    const LOG_DEBUG = 4;
+
+    /**
+     * Log level.
+     */
+    const LOG_TRACE = 5;
+
+   /**
+    * Config variables
+    *
+    * @var array
+    */
+    public $config;
+
+   /**
+    * Socket
+    *
+    * @var resource|null
+    */
+    public $socket = null;
+
+   /**
+    * Server we are connected to
+    *
+    * @var string
+    */
+    public $server;
+
+   /**
+    * Port on the server we are connected to
+    *
+    * @var integer
+    */
+    public $port;
+
+    /**
+     * @var int Used in waitResponse function to prevent looping when true
+     */
+    private $allowTimeout;
+
+   /**
+    * Event Handlers
+    *
+    * @var array
+    */
+    private $eventHandlers;
+
+   /**
+    * Whether we're successfully logged in
+    *
+    * @var boolean
+    */
+    private $loggedIn = false;
+
+    /**
+     * @var int Log level.
+     */
+    private $logLevel = self::LOG_ERROR;
+
+
+   /**
+    * Constructor
+    *
+    * @param string|array $config    Name of the config file to parse.
+    * @param array        $optconfig Array of configuration vars and vals, stuffed into $this->config['asmanager'].
+    */
+    public function __construct($config = null, array $optconfig = [])
+    {
+        // load config
+        if (is_string($config) === true && file_exists($config) === true) {
+            $this->config = parse_ini_file($config, true);
+        } elseif (file_exists(self::DEFAULT_PHPAMI_CONFIG) === true) {
+            $this->config = parse_ini_file(self::DEFAULT_PHPAMI_CONFIG, true);
+        } elseif (file_exists(self::DEFAULT_PHPAGI_CONFIG) === true) {
+            $this->config = parse_ini_file(self::DEFAULT_PHPAGI_CONFIG, true);
+        }
+
+        // If optconfig is specified, stuff vals and vars into 'asmanager' config array.
+        foreach ($optconfig as $var => $val) {
+            $this->config['asmanager'][$var] = $val;
+        }
+
+        // add default values to config for uninitialized values
+        if (isset($this->config['asmanager']['server']) === false) {
+            $this->config['asmanager']['server'] = 'localhost';
+        }
+
+        if (isset($this->config['asmanager']['port']) === false) {
+            $this->config['asmanager']['port'] = 5038;
+        }
+
+        if (isset($this->config['asmanager']['username']) === false) {
+            $this->config['asmanager']['username'] = 'phpagi';
+        }
+
+        if (isset($this->config['asmanager']['secret']) === false) {
+            $this->config['asmanager']['secret'] = 'phpagi';
+        }
+    }//end __construct()
+
+
+   /**
+    * Send a request
+    *
+    * @param string $action     To send.
+    * @param array  $parameters To attach.
+    *
+    * @return array of parameters, empty if invalid socket resource
+    */
+    public function sendRequest($action, array $parameters = [])
+    {    
+				if (!is_resource($this->socket)) {
+    			return [];
+    		}
+    
+        $req = 'Action: '.$action."\r\n";
+        foreach ($parameters as $var => $val) {
+            if (is_array($val) === true) { // only supported by Asterisk > 1.4
+                foreach ($val as $k => $v) {
+                    $req .= $var.': '.$k.'='.$v."\r\n";
+                }
+            } else {
+                $req .= $var.': '.$val."\r\n";
+            }
+        }
+
+        $req .= "\r\n";
+        fwrite($this->socket, $req);
+        $response = $this->waitResponse();
+
+        return $response;
+    }//end sendRequest()
+
+    /**
+     * Set global allowTimeout flag
+     * it will prevent looping waitResponse function
+     *
+     * @param boolean $value
+     * @return void
+     */
+    public function allowTimeout($value = true)
+    {
+        $this->allowTimeout = boolval($value);
+    }//end allowTimeout()
+
+   /**
+    * Wait for a response
+    *
+    * If a request was just sent, this will return the response.
+    * Otherwise, it will loop forever, handling events.
+    *
+    * @param boolean $allowTimeout If the socket times out, return an empty array.
+    *
+    * @return array of parameters, empty on timeout or invalid socket resource
+    */
+    public function waitResponse($allowTimeout = false)
+    {
+        if (!is_resource($this->socket)) {
+            return [];
+        }
+
+        $allowTimeout = $this->allowTimeout ?: $allowTimeout;
+
+        // make sure we haven't already timed out
+        $info = stream_get_meta_data($this->socket);
+        if (feof($this->socket) === true || $info['timed_out'] === true) {
+            return [];
+        }
+
+        $timeout = false;
+        do {
+            $type = null;
+            $parameters = [];
+
+            $buffer = trim(fgets($this->socket, 4096));
+            while ($buffer !== false && $buffer !== '') {
+                $a = strpos($buffer, ':');
+                if ($a !== false) {
+                    if (count($parameters) === 0) { // first line in a response?
+                        $type = strtolower(substr($buffer, 0, $a));
+                        if (substr($buffer, ($a + 2)) === 'Follows') {
+                        // A follows response means there is a miltiline field that follows.
+                            $parameters['data'] = '';
+                            $buff = fgets($this->socket, 4096);
+                            $info = stream_get_meta_data($this->socket);
+                            while (substr($buff, 0, 6) !== '--END '
+                              && $info['timed_out'] !== true
+                              && $info['eof'] !== true
+                            ) {
+                                $parameters['data'] .= $buff;
+                                $buff = fgets($this->socket, 4096);
+                                $info = stream_get_meta_data($this->socket);
+                            }
+                        }
+                    }
+
+                  // store parameter in $parameters
+                    $parameters[substr($buffer, 0, $a)] = substr($buffer, ($a + 2));
+                }//end if
+
+                $buffer = trim(fgets($this->socket, 4096));
+            }//end while
+
+          // process response
+            switch ($type) {
+                case '':
+                    /*
+                    Timeout or connection failure occurred. If not timed_out assume
+                    connection failure and set timeout=true to exit while loop.
+                    */
+                    $info = stream_get_meta_data($this->socket);
+                    $timeout = ($info['timed_out'] === true) ? $allowTimeout : true;
+                    break;
+
+                case 'event':
+                    $this->processEvent($parameters);
+                    break;
+
+                case 'response':
+                    // nothing to process here
+                    break;
+
+                default:
+                    $this->log('Unhandled response packet from Manager: '.print_r($parameters, true), self::LOG_ERROR);
+                    break;
+            }
+        } while ($type !== 'response' && $timeout === false);
+        return $parameters;
+    }//end waitResponse()
+
+
+    /**
+     * Empty receive buffer
+     *
+     * @return flushed buffer
+     */
+    public function flush()
+    {
+        $buffer = fgets($this->socket, 4096);
+        $info = stream_get_meta_data($this->socket);
+        while ($info['timed_out'] !== true && $info['eof'] !== true) {
+            $buffer .= fgets($this->socket, 4096);
+            $info = stream_get_meta_data($this->socket);
+        }
+
+        return $buffer;
+    }//end flush()
+
+
+   /**
+    * Connect to Asterisk
+    *
+    * @param string|null    $server   Hostname to connect to. Recommend FQDN.
+    * @param string|null    $username Username to authenticate with.
+    * @param string|null    $secret   Password for the user.
+    * @param boolean|string $events   Toggle or filter events.
+    *
+    * @return boolean true on success
+    *
+    * @example examples/sip_show_peer.php Get information about a sip peer
+    */
+    public function connect($server = null, $username = null, $secret = null, $events = true)
+    {
+    // use config if not specified
+        if ($server === null) {
+            $server = $this->config['asmanager']['server'];
+        }
+
+        if ($username === null) {
+            $username = $this->config['asmanager']['username'];
+        }
+
+        if ($secret === null) {
+            $secret = $this->config['asmanager']['secret'];
+        }
+
+        // get port from server if specified
+        if (strpos($server, ':') !== false) {
+            $c = explode(':', $server);
+            $this->server = $c[0];
+            $this->port = $c[1];
+        } else {
+            $this->server = $server;
+            $this->port = $this->config['asmanager']['port'];
+        }
+
+        // connect the socket
+        $errno = null;
+        $errstr = null;
+        // TODO: Convert this to a custom error handler to silence the error instead.
+        $this->socket = @fsockopen($this->server, $this->port, $errno, $errstr);
+        if ($this->socket === false) {
+            $this->log(
+                'Unable to connect to manager '.$this->server.':'.$this->port.' ('.$errno.'): '.$errstr,
+                self::LOG_FATAL
+            );
+            return false;
+        }
+
+        // set a 2 second stream timeout
+        stream_set_timeout($this->socket, 2);
+
+        // read the header
+        $str = fgets($this->socket);
+        $info = stream_get_meta_data($this->socket);
+        // note: else: don't $this->log($str) until someone looks to see why it mangles the logging
+        if ($str === false || $info['timed_out'] === true) {
+            // a problem.
+            $this->log('Asterisk Manager header not received.', self::LOG_FATAL);
+            return false;
+        }
+
+        // login
+        $res = $this->sendRequest('login', ['Username' => $username, 'Secret' => $secret]);
+        if ($res['Response'] !== 'Success') {
+            $this->loggedIn = false;
+            $this->log('Failed to login.', self::LOG_FATAL);
+            $this->disconnect();
+            return false;
+        }
+
+        $this->loggedIn = true;
+
+        // default state is to get all events, only send if changed
+        if ($events !== true && $events !== 'on') {
+            $this->events($events);
+        }
+
+        return true;
+    }//end connect()
+
+
+   /**
+    * Disconnect
+    *
+    * @example examples/sip_show_peer.php Get information about a sip peer
+    *
+    * @return void
+    */
+    public function disconnect()
+    {
+        if ($this->loggedIn === true) {
+            $this->logoff();
+        }
+
+        if (is_resource($this->socket)) {
+            fclose($this->socket);
+        }
+    }//end disconnect()
+
+
+    /**
+     * Set Absolute Timeout
+     *
+     * Hangup a channel after a certain time.
+     *
+     * @param string  $channel Channel name to hangup.
+     * @param integer $timeout Maximum duration of the call (sec).
+     *
+     * @return array of parameters
+     *
+     * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+AbsoluteTimeout
+     */
+    public function absoluteTimeout($channel, $timeout)
+    {
+        $result = $this->sendRequest('AbsoluteTimeout', ['Channel' => $channel, 'Timeout' => $timeout]);
+        return $result;
+    }//end absoluteTimeout()
+
+
+   /**
+    * Change monitoring filename of a channel
+    *
+    * @param string $channel The channel to record.
+    * @param string $file    The new name of the file created in the monitor spool directory.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+ChangeMonitor
+    */
+    public function changeMonitor($channel, $file)
+    {
+        $result = $this->sendRequest('ChangeMontior', ['Channel' => $channel, 'File' => $file]);
+        return $result;
+    }//end changeMonitor()
+
+
+   /**
+    * Execute Command
+    *
+    * @param string $command  The command to execute.
+    * @param string $actionId Message matching variable.
+    *
+    * @return array of parameters
+    *
+    * @example examples/sip_show_peer.php Get information about a sip peer
+    * @link    http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+Command
+    * @link    http://www.voip-info.org/wiki-Asterisk+CLI
+    */
+    public function command($command, $actionId = null)
+    {
+        $parameters = ['Command' => $command];
+        if ($actionId !== null) {
+            $parameters['ActionID'] = $actionId;
+        }
+
+        $result = $this->sendRequest('Command', $parameters);
+        return $result;
+    }//end command()
+
+
+   /**
+    * Enable/Disable sending of events to this manager
+    *
+    * @param string|boolean $eventmask Is either 'on', 'off', or 'system,call,log'.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+Events
+    */
+    public function events($eventmask)
+    {
+        if ($eventmask === true) {
+            $eventmask = 'on';
+        } elseif ($eventmask === false) {
+            $eventmask = 'off';
+        }
+
+        $result = $this->sendRequest('Events', ['EventMask' => $eventmask]);
+        return $result;
+    }//end events()
+
+
+   /**
+    * Check Extension Status
+    *
+    * @param string $exten    Extension to check state on.
+    * @param string $context  Context for extension.
+    * @param string $actionId Message matching variable.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+ExtensionState
+    */
+    public function extensionState($exten, $context, $actionId = null)
+    {
+        $parameters = [
+                       'Exten'   => $exten,
+                       'Context' => $context,
+                      ];
+        if ($actionId !== null) {
+            $parameters['ActionID'] = $actionId;
+        }
+
+        $result = $this->sendRequest('ExtensionState', $parameters);
+        return $result;
+    }//end extensionState()
+
+
+   /**
+    * Gets a Channel Variable
+    *
+    * @param string $channel  Channel to read variable from.
+    * @param string $variable To retrieve.
+    * @param string $actionId Message matching variable.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+GetVar
+    * @link http://www.voip-info.org/wiki-Asterisk+variables
+    */
+    public function getVar($channel, $variable, $actionId = null)
+    {
+        $parameters = [
+                       'Channel'  => $channel,
+                       'Variable' => $variable,
+                      ];
+        if ($actionId !== null) {
+            $parameters['ActionID'] = $actionId;
+        }
+
+        $result = $this->sendRequest('GetVar', $parameters);
+        return $result;
+    }//end getVar()
+
+
+   /**
+    * Hangup Channel
+    *
+    * @param string $channel The channel name to be hungup.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+Hangup
+    */
+    public function hangup($channel)
+    {
+        $result = $this->sendRequest('Hangup', ['Channel' => $channel]);
+        return $result;
+    }//end hangup()
+
+
+   /**
+    * List IAX Peers
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+IAXpeers
+    */
+    public function iaxPeers()
+    {
+        $result = $this->sendRequest('IAXPeers');
+        return $result;
+    }//end iaxPeers()
+
+
+   /**
+    * List available manager commands
+    *
+    * @param string $actionId Message matching variable.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+ListCommands
+    */
+    public function listCommands($actionId = null)
+    {
+        if ($actionId !== null) {
+            $result = $this->sendRequest('ListCommands', ['ActionID' => $actionId]);
+        } else {
+            $result = $this->sendRequest('ListCommands');
+        }
+
+        return $result;
+    }//end listCommands()
+
+
+   /**
+    * Logoff Manager
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+Logoff
+    */
+    public function logoff()
+    {
+        $result = $this->sendRequest('Logoff');
+        return $result;
+    }//end logoff()
+
+
+   /**
+    * Check Mailbox Message Count
+    *
+    * Returns number of new and old messages.
+    *   Message: Mailbox Message Count
+    *   Mailbox: <mailboxid>
+    *   NewMessages: <count>
+    *   OldMessages: <count>
+    *
+    * @param string $mailbox  Full mailbox ID <mailbox>@<vm-context>.
+    * @param string $actionId Message matching variable.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+MailboxCount
+    */
+    public function mailboxCount($mailbox, $actionId = null)
+    {
+        $parameters = ['Mailbox' => $mailbox];
+        if ($actionId !== null) {
+            $parameters['ActionID'] = $actionId;
+        }
+
+        $results = $this->sendRequest('MailboxCount', $parameters);
+        return $results;
+    }//end mailboxCount()
+
+
+   /**
+    * Check Mailbox
+    *
+    * Returns number of messages.
+    *   Message: Mailbox Status
+    *   Mailbox: <mailboxid>
+    *   Waiting: <count>
+    *
+    * @param string $mailbox  Full mailbox ID <mailbox>@<vm-context>.
+    * @param string $actionId Message matching variable.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+MailboxStatus
+    */
+    public function mailboxStatus($mailbox, $actionId = null)
+    {
+        $parameters = ['Mailbox' => $mailbox];
+        if ($actionId !== null) {
+            $parameters['ActionID'] = $actionId;
+        }
+
+        $result = $this->sendRequest('MailboxStatus', $parameters);
+        return $result;
+    }//end mailboxStatus()
+
+
+   /**
+    * Monitor a channel
+    *
+    * @param string  $channel To monitor.
+    * @param string  $file    File.
+    * @param string  $format  Format.
+    * @param boolean $mix     Mix.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+Monitor
+    */
+    public function monitor($channel, $file = null, $format = null, $mix = null)
+    {
+        $parameters = ['Channel' => $channel];
+        if ($file !== null) {
+            $parameters['File'] = $file;
+        }
+
+        if ($format !== null) {
+            $parameters['Format'] = $format;
+        }
+
+        if ($file !== null) {
+            if ($mix === true) {
+                $parameters['Mix'] = 'true';
+            } else {
+                $parameters['Mix'] = 'false';
+            }
+        }
+
+        $result = $this->sendRequest('Monitor', $parameters);
+        return $result;
+    }//end monitor()
+
+
+   /**
+    * Originate Call
+    *
+    * @param string  $channel     Channel name to call.
+    * @param string  $exten       Extension to use (requires 'Context' and 'Priority').
+    * @param string  $context     Context to use (requires 'Exten' and 'Priority').
+    * @param string  $priority    Priority to use (requires 'Exten' and 'Context').
+    * @param string  $application Application to use.
+    * @param string  $data        Data to use (requires 'Application').
+    * @param integer $timeout     How long to wait for call to be answered (in ms).
+    * @param string  $callerid    Caller ID to be set on the outgoing channel.
+    * @param string  $variable    Channel variable to set (VAR1=value1|VAR2=value2).
+    * @param string  $account     Account code.
+    * @param boolean $async       True fast origination.
+    * @param string  $actionId    Message matching variable.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+Originate
+    */
+    public function originate(
+        $channel,
+        $exten = null,
+        $context = null,
+        $priority = null,
+        $application = null,
+        $data = null,
+        $timeout = null,
+        $callerid = null,
+        $variable = null,
+        $account = null,
+        $async = null,
+        $actionId = null
+    ) {
+        $parameters = ['Channel' => $channel];
+
+        if ($exten !== null) {
+            $parameters['Exten'] = $exten;
+        }
+
+        if ($context !== null) {
+            $parameters['Context'] = $context;
+        }
+
+        if ($priority !== null) {
+            $parameters['Priority'] = $priority;
+        }
+
+        if ($application !== null) {
+            $parameters['Application'] = $application;
+        }
+
+        if ($data !== null) {
+            $parameters['Data'] = $data;
+        }
+
+        if ($timeout !== null) {
+            $parameters['Timeout'] = $timeout;
+        }
+
+        if ($callerid !== null) {
+            $parameters['CallerID'] = $callerid;
+        }
+
+        if ($variable !== null) {
+            $parameters['Variable'] = $variable;
+        }
+
+        if ($account !== null) {
+            $parameters['Account'] = $account;
+        }
+
+        if ($async !== null) {
+            if ($async === true) {
+                $parameters['Async'] = 'true';
+            } else {
+                $parameters['Async'] = 'false';
+            }
+        }
+
+        if ($actionId !== null) {
+            $parameters['ActionID'] = $actionId;
+        }
+
+        $result = $this->sendRequest('Originate', $parameters);
+        return $result;
+    }//end originate()
+
+
+   /**
+    * List parked calls
+    *
+    * @param string $actionId Message matching variable.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+ParkedCalls
+    */
+    public function parkedCalls($actionId = null)
+    {
+        if ($actionId !== null) {
+            $result = $this->sendRequest('ParkedCalls', ['ActionID' => $actionId]);
+        } else {
+            $result = $this->sendRequest('ParkedCalls');
+        }
+
+        return $result;
+    }//end parkedCalls()
+
+
+   /**
+    * Ping
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+Ping
+    */
+    public function ping()
+    {
+        $result = $this->sendRequest('Ping');
+        return $result;
+    }//end ping()
+
+
+   /**
+    * Queue Add
+    *
+    * @param string  $queue     Queue.
+    * @param string  $interface Interface.
+    * @param integer $penalty   Penalty.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+QueueAdd
+    */
+    public function queueAdd($queue, $interface, $penalty = 0)
+    {
+        $parameters = [
+                       'Queue'     => $queue,
+                       'Interface' => $interface,
+                      ];
+        if ($penalty !== 0) {
+            $parameters['Penalty'] = $penalty;
+        }
+
+        $result = $this->sendRequest('QueueAdd', $parameters);
+        return $result;
+    }//end queueAdd()
+
+
+   /**
+    * Queue Remove
+    *
+    * @param string $queue     Queue.
+    * @param string $interface Interface.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+QueueRemove
+    */
+    public function queueRemove($queue, $interface)
+    {
+        $result = $this->sendRequest('QueueRemove', ['Queue' => $queue, 'Interface' => $interface]);
+        return $result;
+    }//end queueRemove()
+
+
+   /**
+    * Queues
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+Queues
+    */
+    public function queues()
+    {
+        $result = $this->sendRequest('Queues');
+        return $result;
+    }//end queues()
+
+
+   /**
+    * Queue Status
+    *
+    * @param string $actionId Message matching variable.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+QueueStatus
+    */
+    public function queueStatus($actionId = null)
+    {
+        if ($actionId !== null) {
+            $result = $this->sendRequest('QueueStatus', ['ActionID' => $actionId]);
+        } else {
+            $result = $this->sendRequest('QueueStatus');
+        }
+
+        return $result;
+    }//end queueStatus()
+
+
+   /**
+    * Redirect
+    *
+    * @param string $channel      Channel.
+    * @param string $extrachannel Extra Channel.
+    * @param string $exten        Exten.
+    * @param string $context      Context.
+    * @param string $priority     Priority.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+Redirect
+    */
+    public function redirect($channel, $extrachannel, $exten, $context, $priority)
+    {
+        $result = $this->sendRequest(
+            'Redirect',
+            [
+             'Channel'      => $channel,
+             'ExtraChannel' => $extrachannel,
+             'Exten'        => $exten,
+             'Context'      => $context,
+             'Priority'     => $priority,
+            ]
+        );
+
+        return $result;
+    }//end redirect()
+
+
+   /**
+    * Set the CDR UserField
+    *
+    * @param string $userfield User field.
+    * @param string $channel   Channel.
+    * @param string $append    Append.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+SetCDRUserField
+    */
+    public function setCdrUserField($userfield, $channel, $append = null)
+    {
+        $parameters = [
+                       'UserField' => $userfield,
+                       'Channel'   => $channel,
+                      ];
+        if ($append !== null) {
+            $parameters['Append'] = $append;
+        }
+
+        $result = $this->sendRequest('SetCDRUserField', $parameters);
+        return $result;
+    }//end setCdrUserField()
+
+
+   /**
+    * Set Channel Variable
+    *
+    * @param string $channel  Channel to set variable for.
+    * @param string $variable Name.
+    * @param string $value    Value.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+SetVar
+    */
+    public function setVar($channel, $variable, $value)
+    {
+        $result = $this->sendRequest('SetVar', ['Channel' => $channel, 'Variable' => $variable, 'Value' => $value]);
+        return $result;
+    }//end setVar()
+
+
+   /**
+    * Channel Status
+    *
+    * @param string $channel  Channel.
+    * @param string $actionId Message matching variable.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+Status
+    */
+    public function status($channel, $actionId = null)
+    {
+        $parameters = ['Channel' => $channel];
+        if ($actionId !== null) {
+            $parameters['ActionID'] = $actionId;
+        }
+
+        $result = $this->sendRequest('Status', $parameters);
+        return $result;
+    }//end status()
+
+
+   /**
+    * Stop monitoring a channel
+    *
+    * @param string $channel Channel.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+StopMonitor
+    */
+    public function stopMonitor($channel)
+    {
+        $result = $this->sendRequest('StopMonitor', ['Channel' => $channel]);
+        return $result;
+    }//end stopMonitor()
+
+
+   /**
+    * Dial over Zap channel while offhook
+    *
+    * @param string $zapchannel Zap Channel.
+    * @param string $number     Number.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+ZapDialOffhook
+    */
+    public function zapDialOffhook($zapchannel, $number)
+    {
+        $result = $this->sendRequest('ZapDialOffhook', ['ZapChannel' => $zapchannel, 'Number' => $number]);
+        return $result;
+    }//end zapDialOffhook()
+
+
+   /**
+    * Toggle Zap channel Do Not Disturb status OFF
+    *
+    * @param string $zapchannel Zap Channel.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+ZapDNDoff
+    */
+    public function zapDndOff($zapchannel)
+    {
+        $result = $this->sendRequest('ZapDNDoff', ['ZapChannel' => $zapchannel]);
+        return $result;
+    }//end zapDndOff()
+
+
+   /**
+    * Toggle Zap channel Do Not Disturb status ON
+    *
+    * @param string $zapchannel Zap Channel.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+ZapDNDon
+    */
+    public function zapDndOn($zapchannel)
+    {
+        $result = $this->sendRequest('ZapDNDon', ['ZapChannel' => $zapchannel]);
+        return $result;
+    }//end zapDndOn()
+
+
+   /**
+    * Hangup Zap Channel
+    *
+    * @param string $zapchannel Zap Channel.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+ZapHangup
+    */
+    public function zapHangup($zapchannel)
+    {
+        $result = $this->sendRequest('ZapHangup', ['ZapChannel' => $zapchannel]);
+        return $result;
+    }//end zapHangup()
+
+
+   /**
+    * Transfer Zap Channel
+    *
+    * @param string $zapchannel Zap Channel.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+ZapTransfer
+    */
+    public function zapTransfer($zapchannel)
+    {
+        $result = $this->sendRequest('ZapTransfer', ['ZapChannel' => $zapchannel]);
+        return $result;
+    }//end zapTransfer()
+
+
+   /**
+    * Zap Show Channels
+    *
+    * @param string $actionId Message matching variable.
+    *
+    * @return array of parameters
+    *
+    * @link http://www.voip-info.org/wiki-Asterisk+Manager+API+Action+ZapShowChannels
+    */
+    public function zapShowChannels($actionId = null)
+    {
+        if ($actionId !== null) {
+            $result = $this->sendRequest('ZapShowChannels', ['ActionID' => $actionId]);
+        } else {
+            $result = $this->sendRequest('ZapShowChannels');
+        }
+
+        return $result;
+    }//end zapShowChannels()
+
+
+   /**
+    * Log a message
+    *
+    * @param string  $message Message to log.
+    * @param integer $level   From 1 to 4.
+    *
+    * @return void
+    */
+    public function log($message, $level = self::LOG_INFO)
+    {
+        if ($level <= $this->logLevel) {
+            error_log(date('r').' - '.$message);
+        }
+    }//end log()
+
+
+    /**
+     * @param integer $level Log Level to use.
+     *
+     * @return void
+     * @throws \InvalidArgumentException Invalid Log level.
+     *
+     * @since 2015-07-25
+     */
+    public function setLogLevel($level)
+    {
+        if ($level < self::LOG_FATAL || $level > self::LOG_TRACE) {
+            throw new \InvalidArgumentException('Invalid Log Level');
+        }
+
+        $this->logLevel = $level;
+    }//end setLogLevel()
+
+
+   /**
+    * Add event handler
+    *
+    * Known Events include ( http://www.voip-info.org/wiki-asterisk+manager+events )
+    *   Link - Fired when two voice channels are linked together and voice data exchange commences.
+    *   Unlink - Fired when a link between two voice channels is discontinued, for example, just before call completion.
+    *   Newexten -
+    *   Hangup -
+    *   Newchannel -
+    *   Newstate -
+    *   Reload - Fired when the "RELOAD" console command is executed.
+    *   Shutdown -
+    *   ExtensionStatus -
+    *   Rename -
+    *   Newcallerid -
+    *   Alarm -
+    *   AlarmClear -
+    *   Agentcallbacklogoff -
+    *   Agentcallbacklogin -
+    *   Agentlogoff -
+    *   MeetmeJoin -
+    *   MessageWaiting -
+    *   join -
+    *   leave -
+    *   AgentCalled -
+    *   ParkedCall - Fired after ParkedCalls
+    *   Cdr -
+    *   ParkedCallsComplete -
+    *   QueueParams -
+    *   QueueMember -
+    *   QueueStatusEnd -
+    *   Status -
+    *   StatusComplete -
+    *   ZapShowChannels - Fired after ZapShowChannels
+    *   ZapShowChannelsComplete -
+    *
+    * @param string $event    Type or * for default handler.
+    * @param string $callback Function.
+    *
+    * @return boolean sucess
+    */
+    public function addEventHandler($event, $callback)
+    {
+        $event = strtolower($event);
+        if (isset($this->eventHandlers[$event]) === true) {
+            $this->log($event.' handler is already defined, not over-writing.', self::LOG_ERROR);
+            return false;
+        }
+
+        $this->eventHandlers[$event] = $callback;
+        return true;
+    }//end addEventHandler()
+
+
+   /**
+    * Process event
+    *
+    * @param array $parameters Parameters.
+    *
+    * @return mixed result of event handler or false if no handler was found
+    */
+    public function processEvent(array $parameters)
+    {
+        $ret = false;
+        $e = strtolower($parameters['Event']);
+        $this->log('Got event: '.$e, self::LOG_INFO);
+
+        $handler = '';
+        if (isset($this->eventHandlers[$e]) === true) {
+            $handler = $this->eventHandlers[$e];
+        } elseif (isset($this->eventHandlers['*']) === true) {
+            $handler = $this->eventHandlers['*'];
+        }
+
+        if (function_exists($handler) === true) {
+            $this->log('Execute handler: '.$handler, self::LOG_DEBUG);
+            $ret = $handler($e, $parameters, $this->server, $this->port);
+        } else {
+            $this->log('No event handler for event: '.$e, self::LOG_DEBUG);
+        }
+
+        return $ret;
+    }//end processEvent()
+
+
+    /**
+     * @param string $input To split.
+     *
+     * @return array of output lines
+     * @since 2015-07-26
+     */
+    public function split($input)
+    {
+        $output = preg_split('/[\t\n]+/', $input);
+        return $output;
+    }//end split()
+}//end class

--- a/izpbx-asterisk/rootfs/usr/local/share/autoban/autoban.class.inc
+++ b/izpbx-asterisk/rootfs/usr/local/share/autoban/autoban.class.inc
@@ -1,0 +1,226 @@
+<?php
+/*------------------------------------------------------------------------------
+ The Autoban class provides functions for watching and jailing IP addresses
+ using nftables.
+ The state information is represented by timeouts in NFT, so that it can be
+ recovered after a system reboot.
+
+ The NFT set 'watch' hold a watch list of IPs. The watch count is represented by
+ the number of seconds beyond 'watchtime' in the timeout
+
+ The NFT set 'jail' hold IPs that whose packets will be dropped by NFT. When
+ the timeout completes the IP is released.
+
+ The NFT set 'parole' hold a list of IPs which was recently released. If watched
+ during the parole time the IP is immediately jailed again and now 'repeatmult'
+ longer.
+*/
+require_once 'nft.class.inc';
+
+class Autoban extends Nft {
+	private const DEFAULT_CONF_FILE = '/etc/asterisk/autoban.conf';
+	public const DEFAULT_CONF_VALS = [
+		'enabled'    => true,
+		'maxcount'   => 10,
+		'watchtime'  => '20m',
+		'jailtime'   => '20m',
+		'repeatmult' => 6,
+	];
+	public const NFT_SETS = ['watch','jail','parole','blacklist','whitelist'];
+	private const TIME_MAXSEC = 99999999;
+	public $config;
+	public $debug = false;
+	public function __construct($config = null, array $optconfig = []) {
+		parent::__construct();
+		if (is_string($config) !== true) {
+			$config = self::DEFAULT_CONF_FILE;
+		}
+		$this->config['autoban'] = self::DEFAULT_CONF_VALS;
+		if (file_exists($config) === true) {
+			$config_ini = parse_ini_file($config,true);
+			if (!empty($config_ini['autoban']))
+				$this->config['autoban'] = array_merge($this->config['autoban'],
+					$config_ini['autoban']);
+		} else {
+			$this->config['autoban']['enabled'] = false;
+		}
+		foreach ($optconfig as $var => $val) {
+			$this->config['autoban'][$var] = $val;
+		}
+	}
+	/*--------------------------------------------------------------------------
+	Start to count how many time we watch an IP address $ip by adding it to the
+	'watch' NFT set and use the number of seconds of its timeout > 'watchtime'
+	as a counter. If count is > 'maxcount' add $ip to 'jail' and 'parole' NFT 
+	sets with timeouts 'jailtime' and jailtime'+'watchtime'. If $ip is watched
+	during its parole immediately add it again to the 'jail' and 'parole' NFT sets 
+	with timeouts 'repeatmult' longer than previously.
+
+	@param  string  $ip  eg "23.94.144.50"
+	@return boolean success
+	*/
+	public function book($ip) {
+		// if not already in jail but on parole or watch count > maxcount
+		// determine sentence and increment jail and parole counters
+		if(ip2long($ip) === false) {
+			trigger_error(sprintf('Got invalid IP address (%s)',$ip),E_USER_WARNING);
+			return false;
+		}
+		$log = null;
+		$watch_nft  = $this->timeoutsec('watch',$ip);
+		$jail_nft   = $this->timeoutsec('jail',$ip);
+		$parole_nft = $this->timeoutsec('parole',$ip);
+		$watch_new  = $this->incrementwatch($watch_nft);
+		$jail_new   = $this->jailsec($watch_new,$jail_nft,$parole_nft);
+		$parole_new = $this->parolesec($jail_new);
+		if ($jail_nft === false) {
+			if($jail_new !== false) {
+				$log = 'jail';
+				$watch_new = false;
+				if ($parole_nft !== false) $this->del_addrs('parole',$ip);
+			} else {
+				$log = 'watch';
+				if ($watch_nft !== false) $this->del_addrs('watch',$ip);
+			}
+		}
+		if ($this->add_addrs('watch',$ip,$watch_new) === false) return false;
+		if ($this->add_addrs('jail',$ip,$jail_new) === false) return false;
+		if ($this->add_addrs('parole',$ip,$parole_new) === false) return false;
+		switch ($log) {
+			case 'watch':
+				$this->log(sprintf('Watching %15s %-8d',$ip,
+					$this->countwatch($watch_new)));
+				break;
+			case 'jail':
+				$this->log(sprintf('Jailing  %15s %8s',$ip,
+					$this->timestr($jail_new)),null,E_USER_WARNING);
+				break;
+		}
+		if ($this->save() === false) return false;
+		return true;
+	}
+	/*--------------------------------------------------------------------------
+	Increment both watch count and watchtime, illustrated below, watchtime=20m.
+		$time $count $time
+		false      1 20m1s
+		20m1s      2 20m2s
+		20m2s      3 20m3s
+		20m3s      4 20m4s
+		20m4s      5 20m5s
+
+	@param  mixed   $time integer time in seconds or boolean false
+	@return integer time + 1
+	*/
+	private function incrementwatch($time) {
+		if($time === false) {
+			return $this->configsec('watchtime') + 1;
+		} else {
+			return $time + 1;
+		}
+	}
+	/*--------------------------------------------------------------------------
+	@param  integer $time integer time in seconds
+	@return integer count
+	*/
+	private function countwatch($time) {
+		return $time - $this->configsec('watchtime');
+	}
+	/*--------------------------------------------------------------------------
+	Compute sentencing time which is last jailtime times repeatmult if in parole.
+	Sentencing is jailtime if first time offender watch count >= maxcount.
+	Return false if already in jail or watch count < maxcount.
+
+	@param  mixed $watchtime integer time in seconds or boolean false
+	@param  mixed $jailtime integer time in seconds or boolean false
+	@param  mixed $paroletime integer time in seconds or boolean false
+	@return mixed integer sentence time in seconds or boolean false
+	*/
+	private function jailsec($watchtime,$jailtime,$paroletime) {
+		if ($jailtime !== false) return false;
+		if ($paroletime !== false) {
+			$jailt = max($this->configsec('jailtime'),
+				$paroletime - $this->configsec('watchtime'));
+			return $jailt * $this->config['autoban']['repeatmult'];
+		} elseif (($watchtime !== false) &&
+			($watchtime - $this->configsec('watchtime') >=
+			$this->config['autoban']['maxcount'])) {
+			return $sentence = $this->configsec('jailtime');
+		}
+		return false;
+	}
+	/*--------------------------------------------------------------------------
+	Compute probation time = sentence time + watchtime. Also make sure both
+	probation and sentence times are sane.
+
+	@param  mixed &$sentence integer time in seconds or boolean false
+	@return mixed integer probation time in seconds or boolean false
+	*/
+	private function parolesec(&$sentence) {
+		if ($sentence === false) return false;
+		$watchtime = $this->configsec('watchtime');
+		if ($watchtime > 0.5*self::TIME_MAXSEC) $watchtime = 0.5*self::TIME_MAXSEC;
+		$parole = $sentence + $watchtime;
+		if ($parole > self::TIME_MAXSEC) {
+			$parole = self::TIME_MAXSEC;
+			$sentence = $parole - $watchtime;
+		}
+		$sentence = round($sentence);
+		return round($parole);
+	}
+	/*--------------------------------------------------------------------------
+	@param  string $set eg "jail"
+	@param  string $ip  eg "23.94.144.50"
+	@return mixed  time integer seconds or boolean false
+	*/
+	public function timeoutsec($set,$ip) {
+		return $this->str2sec($this->get_timeout($set,$ip));
+	}
+	/*--------------------------------------------------------------------------
+	@param  string $set eg "jail"
+	@return mixed  time integer seconds or boolean false
+	*/
+	public function configtime($set) {
+		switch ($set) {
+		case 'watch':
+			$sec = $this->configsec('watchtime');
+			break;
+		case 'jail':
+			$sec = $this->configsec('jailtime');
+			break;
+		case 'parole':
+			$sec = $this->configsec('jailtime') + $this->configsec('watchtime');
+			break;
+		default:
+			$sec = null;
+		}
+		return $this->sec2str($sec);
+	}
+	/*--------------------------------------------------------------------------
+	Convert config times in sting format to seconds eg "20m" to 1200
+	@param  string  $param eg, "watchtime"
+	@return integer $seconds
+	*/
+	public function configsec($param) {
+		$time = $this->config['autoban'][$param];
+		if(!is_numeric($time)) $time = $this->str2sec($time);
+		return $time;
+	}
+	/*--------------------------------------------------------------------------
+	@param  string  $message eg "Jailing 23.94.144.50"
+	@param  mixed   $error eg 404
+	@param  integer $level eg E_USER_WARNING
+	@return void
+	*/
+	public function log($message, $error = [], $level = E_USER_NOTICE) {
+		if (isset($error[0])) {
+			$message = $message.' error: '.$error[0];
+		} else {
+			$nr_watch = count($this->list('watch'));
+			$nr_jail = count($this->list('jail'));
+			$message = sprintf('%s (watch %-3d jail %-3d)',
+				$message,$nr_watch,$nr_jail);
+		}
+		trigger_error($message, $level);
+	}
+}
+?>

--- a/izpbx-asterisk/rootfs/usr/local/share/autoban/autoban.conf
+++ b/izpbx-asterisk/rootfs/usr/local/share/autoban/autoban.conf
@@ -1,0 +1,20 @@
+;
+; autoban.conf
+;
+; This file hold user customization of the AutoBan intrusion detection and
+; prevention system. This is a php ini file. Luckily its syntax is similar to
+; other asterisk conf files. "yes" and "no" have to be within quotation marks
+; otherwise they will be interpreted as Boolean.
+;
+
+[asmanager]
+server     = 127.0.0.1
+port       = 5038
+username   = autoban
+secret     = N0ob75lEi2TbVp07TS4F1xPcod39S5
+
+[autoban]
+maxcount   = 10
+watchtime  = 20m
+jailtime   = 20m
+repeatmult = 6

--- a/izpbx-asterisk/rootfs/usr/local/share/autoban/autoban.conf.sample
+++ b/izpbx-asterisk/rootfs/usr/local/share/autoban/autoban.conf.sample
@@ -1,0 +1,20 @@
+;
+; autoban.conf
+;
+; This file hold user customization of the AutoBan intrusion detection and
+; prevention system. This is a php ini file. Luckily its syntax is similar to
+; other asterisk conf files. "yes" and "no" have to be within quotation marks
+; otherwise they will be interpreted as Boolean.
+;
+
+[asmanager]
+server     = 127.0.0.1
+port       = 5038
+username   = autoban
+secret     = N0ob75lEi2TbVp07TS4F1xPcod39S5
+
+[autoban]
+maxcount   = 10
+watchtime  = 20m
+jailtime   = 20m
+repeatmult = 6

--- a/izpbx-asterisk/rootfs/usr/local/share/autoban/autoban.nft
+++ b/izpbx-asterisk/rootfs/usr/local/share/autoban/autoban.nft
@@ -1,0 +1,31 @@
+#!/usr/sbin/nft -f
+#
+
+table ip autoban {
+	set watch {
+		type ipv4_addr
+		flags timeout
+	}
+	set jail {
+		type ipv4_addr
+		flags timeout
+	}
+	set parole {
+		type ipv4_addr
+		flags timeout
+	}
+	set blacklist {
+		type ipv4_addr
+	}
+	set whitelist {
+		type ipv4_addr
+	}
+
+	#TODO adjust 'dport' according to asterisk transport settings 
+	chain incoming {
+		type filter hook input priority security; policy accept;
+		ip saddr @whitelist accept
+		ip saddr @blacklist EXTRA_NFT_PORT_RULES drop
+		ip saddr @jail EXTRA_NFT_PORT_RULES drop
+	}
+}

--- a/izpbx-asterisk/rootfs/usr/local/share/autoban/autoban.nft.sample
+++ b/izpbx-asterisk/rootfs/usr/local/share/autoban/autoban.nft.sample
@@ -1,0 +1,31 @@
+#!/usr/sbin/nft -f
+#
+
+table ip autoban {
+	set watch {
+		type ipv4_addr
+		flags timeout
+	}
+	set jail {
+		type ipv4_addr
+		flags timeout
+	}
+	set parole {
+		type ipv4_addr
+		flags timeout
+	}
+	set blacklist {
+		type ipv4_addr
+	}
+	set whitelist {
+		type ipv4_addr
+	}
+
+	#TODO adjust 'dport' according to asterisk transport settings 
+	chain incoming {
+		type filter hook input priority security; policy accept;
+		ip saddr @whitelist accept
+		ip saddr @blacklist EXTRA_NFT_PORT_RULES drop
+		ip saddr @jail EXTRA_NFT_PORT_RULES drop
+	}
+}

--- a/izpbx-asterisk/rootfs/usr/local/share/autoban/autoban.php
+++ b/izpbx-asterisk/rootfs/usr/local/share/autoban/autoban.php
@@ -1,0 +1,177 @@
+#!/usr/bin/env php
+<?php
+/*------------------------------------------------------------------------------
+ autoban.php
+*/
+$HELP_MESSAGE = <<<HELP_MESSAGE
+
+  DESCRIPTION
+    Shows an overview of the NFT state, which autoban uses to track IP adresses.
+    Addresses can also be added or deleted.
+
+  USAGE
+    autoban [SUBCOMMAND]
+      If no subcommand is given use "show".
+
+  SUBCOMMAND
+    add <dsets> = <ssets> <addrs>   Add to <dsets>, <addrs> and/or
+                                    addrs from <ssets>.
+    del <dsets> = <ssets> <addrs>   Delete from <dsets>, <addrs> and/or
+                                    addrs from <ssets>.
+    list <sets>                     List addrs from <sets>.
+    help                            Print this text.
+    show                            Show overview of the NFT state.
+
+  EXAMPLES
+    Blacklist 77.247.110.24 and 62.210.151.21 and all addresses from jail
+      autoban add blacklist = 77.247.110.24 jail 62.210.151.21
+
+    Add all addresses in the watch set to the jail and parole sets
+      autoban add jail parole = watch
+
+    Delete 37.49.230.37 and all addresses in blacklist from jail parole
+      autoban del jail parole = 37.49.230.37 blacklist
+
+    Delete 45.143.220.72 from all sets
+      autoban del all = 45.143.220.72
+
+    Delete all addresses from all sets
+      autoban del all = all
+
+
+HELP_MESSAGE;
+
+/*------------------------------------------------------------------------------
+ Initiate logging and load dependencies.
+*/
+openlog("autoban", LOG_PID | LOG_PERROR, LOG_LOCAL0);
+require_once 'error.inc';
+require_once 'autoban.class.inc';
+
+/*------------------------------------------------------------------------------
+ Create class objects and set log level.
+*/
+$ban = new Autoban();
+
+/*--------------------------------------------------------------------------
+Add elements $addr to NFT set $set
+@param  array of strings $args eg ["blacklist", "=", "77.247.110.24", "jail"]
+@return boolean false if unable to add element else true
+*/
+function add($args) {
+	global $ban;
+	parse($args,$dargs,$sargs,'blacklist');
+	foreach ($dargs as $dset) {
+		$timeout = $ban->configtime($dset);
+		$assume_ssets = array_intersect($sargs,Autoban::NFT_SETS);
+		$assume_saddrs = array_diff($sargs,Autoban::NFT_SETS);
+		foreach ($assume_ssets as $sset) {
+			$saddrs = array_keys($ban->list($sset));
+			$ban->add_addrs($dset, $saddrs, $timeout);
+		}
+		$ban->add_addrs($dset, $assume_saddrs, $timeout, true);
+	}
+	$ban->save();
+}
+
+/*--------------------------------------------------------------------------
+Delete elements $args from NFT sets $sets
+@param  array of strings $args eg ["blacklist", "=", "77.247.110.24", "jail"]
+@return boolean false if unable to delete element else true
+*/
+function del($args) {
+	global $ban;
+	parse($args,$dargs,$sargs,'all');
+	if (array_search('all', $dargs) !== false) $dargs = Autoban::NFT_SETS;
+	foreach ($dargs as $dset) {
+		$assume_ssets = array_intersect($sargs,Autoban::NFT_SETS);
+		foreach ($assume_ssets as $sset) {
+			$saddrs = array_keys($ban->list($sset));
+			$ban->del_addrs($dset, $saddrs);
+		}
+		$assume_saddrs = array_diff($sargs,Autoban::NFT_SETS);
+		$ban->del_addrs($dset, $assume_saddrs);
+	}
+	$ban->save();
+}
+
+/*--------------------------------------------------------------------------
+List elements in NFT sets $sets
+@param  array of strings $args eg ["blacklist", "jail"]
+@return void
+*/
+function ls($args) {
+	global $ban;
+	if (empty($args) || array_search('all', $args) !== false)
+		$args = Autoban::NFT_SETS;
+	foreach ($args as $set)
+		if (count($args) === 1)
+			printf("%s\n", implode(' ',array_keys($ban->list($set))));
+		else
+			printf("%s: %s\n", $set, implode(' ',array_keys($ban->list($set))));
+}
+
+/*--------------------------------------------------------------------------
+Separates argument in to $dargs and $sargs using the separator
+@param  array of strings $args eg ["blacklist", "=", "77.247.110.24", "jail"]
+@param  array of strings $dargs eg ["blacklist"]
+@param  array of strings $sargs eg ["77.247.110.24", "jail"]
+@return void
+*/
+function parse($args, &$dargs, &$sargs, $default = 'all', $separators = ':+-=') {
+	$left = []; $right = [];
+	foreach ($args as $arg) {
+		if (strlen($arg) === 1 && strstr($separators, $arg) !== false) {
+			$mid = $arg;
+		} else {
+			if (empty($mid)) {
+				array_push($left, $arg);
+			} else {
+				array_push($right, $arg);
+			}
+		}
+	}
+	if (empty($right)) {
+		$dargs = [$default];
+		$sargs = $left;
+	} else {
+		$dargs = $left;
+		$sargs = $right;
+	}
+}
+/*------------------------------------------------------------------------------
+ Start code execution.
+ Scrape off command and sub-command and pass the rest of the arguments.
+*/
+#$ban->debug = true;
+$subcmd=@$argv[1];
+unset($argv[0],$argv[1]);
+#if(!empty($subcmd))
+#	trigger_error(sprintf('Running %s %s', $subcmd, implode(' ',$argv)),
+#		E_USER_NOTICE);
+switch (@$subcmd) {
+	case 'add':
+	case 'a':
+		add(@$argv);
+		break;
+	case 'delete':
+	case 'del':
+	case 'd':
+		del(@$argv);
+		break;
+	case 'list':
+	case 'ls':
+	case 'l':
+		ls(@$argv);
+		break;
+	case 'show':
+	case 's':
+	case '':
+		$ban->show();
+		break;
+	case 'help':
+	default:
+		print $HELP_MESSAGE;
+		break;
+}
+?>

--- a/izpbx-asterisk/rootfs/usr/local/share/autoban/autoband.php
+++ b/izpbx-asterisk/rootfs/usr/local/share/autoban/autoband.php
@@ -1,0 +1,83 @@
+#!/usr/bin/env php
+<?php
+/*------------------------------------------------------------------------------
+ autoband.php
+*/
+
+/*------------------------------------------------------------------------------
+ Initiate logging and load dependencies.
+*/
+openlog("autoband", LOG_PID|LOG_CONS|LOG_PERROR, LOG_LOCAL0);
+require_once 'error.inc';
+require_once 'ami.class.inc';
+require_once 'autoban.class.inc';
+
+/*------------------------------------------------------------------------------
+ Define AMI event handlers.
+*/
+function eventAbuse($event,$parameters,$server,$port) {
+	global $ban;
+	if (array_key_exists('RemoteAddress',$parameters)) {
+		$address = explode('/',$parameters['RemoteAddress']);
+		$ip = $address[2];
+		if (!empty($ip)) {
+			$ban->book($ip);
+		}
+	}
+}
+
+/*------------------------------------------------------------------------------
+ Create class objects and set log level.
+*/
+$ban = new \Autoban('/etc/asterisk/autoban.conf');
+$ami = new \PHPAMI\Ami('/etc/asterisk/autoban.conf');
+$ami->setLogLevel(2);
+
+/*------------------------------------------------------------------------------
+ Register the AMI event handlers to their corresponding events.
+*/
+$ami->addEventHandler('FailedACL',               'eventAbuse');
+$ami->addEventHandler('InvalidAccountID',        'eventAbuse');
+$ami->addEventHandler('ChallengeResponseFailed', 'eventAbuse');
+$ami->addEventHandler('InvalidPassword',         'eventAbuse');
+
+/*------------------------------------------------------------------------------
+ Start code execution.
+ Wait 1s allowing Asterisk time to setup the Asterisk Management Interface (AMI).
+ If autoban is activated try to connect to the AMI. If successful, start
+ listening for events indefinitely. If connection fails, retry to connect.
+ If autoban is deactivated stay in an infinite loop instead of exiting.
+ Otherwise the system supervisor will relentlessly just try to restart us.
+*/
+
+define("MAX_WAIT_RETRIES",10);
+
+$wait_init  = 5; // 5secs to try to connect
+$wait_extra = 55; // wait 55secs after failed attempt
+$wait_retries = MAX_WAIT_RETRIES;
+$wait_off   = 3600;
+if ($ban->config['autoban']['enabled']) {
+	while($wait_retries--) {
+		sleep($wait_init);
+		if ($ami->connect()) {
+			trigger_error('Activated and connected to AMI',E_USER_NOTICE);
+			$ami->waitResponse(); // listen for events until connection fails
+			$ami->disconnect();
+			$wait_retries=MAX_WAIT_RETRIES; // reload wait retry counter after every successful connect
+		} else {
+			trigger_error('Unable to connect to AMI',E_USER_ERROR);
+			sleep($wait_extra);
+		}
+	}
+	trigger_error('MAX_WAIT_RETRIES exceeded. Giving up finally.',E_USER_ERROR);
+} else {
+	trigger_error('Disabled! Activate autoban using conf file '.
+	'(/etc/asterisk/autoban.conf)',E_USER_NOTICE);
+	while($ban->config['autoban']['stayalive']) { sleep($wait_off); }
+}
+
+
+/*------------------------------------------------------------------------------
+ We will never come here.
+*/
+?>

--- a/izpbx-asterisk/rootfs/usr/local/share/autoban/error.inc
+++ b/izpbx-asterisk/rootfs/usr/local/share/autoban/error.inc
@@ -1,0 +1,36 @@
+<?php
+/**
+* Define error handler,
+* and activating it.
+* An error is triggerd by calling:
+* trigger_error(message, type)
+* type is one of E_USER_ERROR, E_USER_WARNING, E_USER_NOTICE (the default).
+*/
+function errorHandler($errno, $errstr, $errfile, $errline) {
+	if (!(error_reporting() & $errno)) return false;
+	$err_core_text = "[$errno]: ".basename($errfile).":$errline: $errstr";
+	switch ($errno) {
+	case E_USER_ERROR:
+		$err_log_code = LOG_ERR;
+		$err_log_text = "ERROR$err_core_text.";
+		break;
+	case E_USER_WARNING:
+	case E_WARNING:
+	case E_NOTICE:
+		$err_log_code = LOG_WARNING;
+		$err_log_text = "WARNING$err_core_text.";
+		break;
+	case E_USER_NOTICE:
+		$err_log_code = LOG_NOTICE;
+		$err_log_text = "NOTICE$err_core_text.";
+		break;
+	default:
+		$err_log_code = LOG_DEBUG;
+		$err_log_text = "UNKNOWN$err_core_text.";
+		break;
+	}
+	syslog($err_log_code,$err_log_text);
+	return true; /* Don't execute PHP internal error handler */
+}
+set_error_handler("errorHandler");
+?>

--- a/izpbx-asterisk/rootfs/usr/local/share/autoban/nft.class.inc
+++ b/izpbx-asterisk/rootfs/usr/local/share/autoban/nft.class.inc
@@ -168,7 +168,9 @@ class Nft {
 	@return mixed  state string or boolean false if unsuccessful
 	*/
 	public function save() {
-		$args = ['sub'=>'list ruleset', 'family'=>null, 'table'=>null];
+		// $args = ['sub'=>'list ruleset', 'family'=>null, 'table'=>null];
+		// save only table 'autoban'
+		$args = ['sub'=>'list table autoban', 'family'=>null, 'table'=>null];
 		$return = $this->exec($args);
 		if ($return === false) return false;
 		@rename($this->nft_statefile, $this->nft_statefile.'~');

--- a/izpbx-asterisk/rootfs/usr/local/share/autoban/nft.class.inc
+++ b/izpbx-asterisk/rootfs/usr/local/share/autoban/nft.class.inc
@@ -1,0 +1,327 @@
+<?php
+/*------------------------------------------------------------------------------
+ The Nft class provides functions edit and save the state of nftables.
+*/
+class Nft {
+	private const NFT_SYNTAX = [
+		'cmd'    => 'nft',
+		'opt'    => '--stateless',
+		'sub'    => null,
+		'family' => 'ip',
+		'table'  => 'autoban',
+		'chain'  => null,
+		'set'    => null,
+		'val'    => null,
+		'stderr' => '2>&1',
+	];
+	public const NFT_SETS = ['watch','jail','parole','blacklist','whitelist'];
+	private const TIME_UNITS = ['d' => 86400, 'h' => 3600, 'm' => 60, 's' => 1];
+	private const SHOW_MARK = 'X';
+	private const SHOW_ID = 'addr';
+	private const NFT_DIR = '/etc/nftables';
+	private const NFT_FILE = 'autoban.nft';
+	private $nft_statefile;
+	public $debug = false;
+	/*--------------------------------------------------------------------------
+	Constructor
+	@return void
+	*/
+	public function __construct() {
+		$nft_dir = (getenv('DOCKER_NFT_DIR') !== false) ?
+			getenv('DOCKER_NFT_DIR') : self::NFT_DIR;
+		$nft_file = (getenv('DOCKER_NFT_FILE') !== false) ?
+			getenv('DOCKER_NFT_FILE') : self::NFT_FILE;
+		$this->nft_statefile = $nft_dir.'/'.$nft_file;
+	}
+	/*--------------------------------------------------------------------------
+	Add element $addr to NFT set $set with timeout $timeout seconds
+	@param  string $set eg "jail"
+	@param  string $addr eg "23.94.144.50"
+	@param  mixed  $timeout int seconds eg 1200 or boolean false
+	@return boolean false if unable to add element else true
+	*/
+	public function add($set, $addr, $timeout = null, $check = false) {
+		if ($check && !$this->is_addr($addr)) return false;
+		if ($this->add_addrs($set,$addr,$timeout) === false) return false;
+		if ($this->save() === false) return false;
+		return true;
+	}
+	/*--------------------------------------------------------------------------
+	Delete element $addr from NFT set $set
+	@param  string $set eg "jail"
+	@param  string $addr eg "23.94.144.50"
+	@return mixed  boolean false if unable to del element else true
+	*/
+	public function del($set, $addr = null, $check = false) {
+		if ($check) if (!$this->is_addr($addr)) return false;
+		if ($this->del_addrs($set,$addr) === false) return false;
+		if ($this->save() === false) return false;
+		return true;
+	}
+	/*--------------------------------------------------------------------------
+	Get array of all addr in set $set.
+	@param  string $set eg "jail"
+	@return array  [string addr => string time, ...] or [] is set is empty
+	*/
+	public function list($set) {
+		$return = $this->list_addr($set);
+		if ($return === false) return [];
+		return $this->array_elem($return);
+	}
+	/*--------------------------------------------------------------------------
+	Get timeout for $addr from NFT set $set
+	@param  string $set eg "jail"
+	@param  string $addr eg "23.94.144.50"
+	@return mixed  exec return string or boolean false if unable to get timeout
+	*/
+	public function get_timeout($set,$addr) {
+		$timeout = $this->array_elem($this->get_addr($set,$addr));
+		if (!empty($timeout)) return array_values($timeout)[0];
+		return false;
+	}
+	/*--------------------------------------------------------------------------
+	Add element $addr to NFT set $set with timeout $timeout seconds
+	@param  string $set eg "jail"
+	@param  mixed  $addrs string eg "23.94.144.50" or array ["23.94.144.50",...] or null or false
+	@param  mixed  $timeout int seconds eg 1200 or boolean false
+	@return mixed  exec return string or boolean false if unable to add elements
+	*/
+	public function add_addrs($set,$addrs,$timeout = null) {
+		if (empty($addrs) || $timeout === false) return true;
+		$suffix = (empty($timeout)) ? '' : ' timeout '.$this->timestr($timeout);
+		if(is_array($addrs)) {
+			$addrs = array_map(function($a) use ($suffix) { return $a.$suffix; }, $addrs);
+			$val = implode(', ', $addrs);
+		} else {
+			$val = $addrs.$suffix;
+		}
+		$args = ['sub'=>'add element', 'set'=>$set, 'val'=>'{'.$val.'}'];
+		return $this->exec($args);
+	}
+	/*--------------------------------------------------------------------------
+	Delete element $addr from NFT set $set
+	@param  string $set eg "jail"
+	@param  mixed  $addrs string eg "23.94.144.50" or array ["23.94.144.50","all",...] or null
+	@return mixed  exec return string or boolean false if unable to del elements
+	*/
+	public function del_addrs($set, $addrs = null) {
+		if (empty($addrs)) return true;
+		$given_addrs = (is_array($addrs)) ? $addrs : [$addrs];
+		if (array_search('all', $given_addrs) !== false) {
+			$args = ['sub'=>'flush set','set'=>$set];
+		} else {
+			$valid_addrs = array_keys($this->list($set));
+			$the_addrs = array_intersect($given_addrs, $valid_addrs);
+			if (empty($the_addrs)) return true;
+			$val = implode(', ', $the_addrs);
+			$args = ['sub'=>'delete element','set'=>$set,'val'=>'{'.$val.'}'];
+		}
+		return $this->exec($args);
+	}
+	/*--------------------------------------------------------------------------
+	Get element $addr from NFT set $set
+	@param  string $set eg "jail"
+	@param  string $addr eg "23.94.144.50"
+	@return mixed  exec return string or boolean false if unable to del element
+	*/
+	public function get_addr($set,$addr) {
+		if (empty($addr)) return true;
+		$args = ['sub'=>'get element','set'=>$set,'val'=>'{'.$addr.'}'];
+		return $this->exec($args, false);
+	}
+	/*--------------------------------------------------------------------------
+	List elements in NFT set $set
+	@param  string $set eg "jail"
+	@return mixed  exec return string or boolean false if unable to del element
+	*/
+	public function list_addr($set) {
+		$args = ['sub'=>'list set','set'=>$set];
+		return $this->exec($args);
+	}
+	/*--------------------------------------------------------------------------
+	NFT returns elements = { 23.94.144.50 timeout 40m, ...}
+	We stuff this into $this->timeout[$set] = [string addr => string time, ...].
+
+	@param  array  $return strings return from calling NFT
+	@return array  [string addr => string time, ...] or [] is set is empty
+	*/
+	public function array_elem($return) {
+		if ($return === false) return [];
+		preg_match('/flags timeout/', implode($return), $hastimeout);
+		preg_match('/elements = {([^}]+)}/', implode($return), $matches);
+		if (empty($matches[1])) return [];
+		$elements = preg_split('/,/', $matches[1]);
+		$timeout = [];
+		foreach ($elements as $element) {
+			if (empty($hastimeout)) {
+				$timeout += [trim($element) => Self::SHOW_MARK];
+			} else {
+				$addrntime = explode(' timeout ',$element);
+				$timeout += [trim($addrntime[0]) => trim($addrntime[1])];
+			}
+		}
+		return $timeout;
+	}
+	/*--------------------------------------------------------------------------
+	Save NFT state to file. Rename the old state file by appending "~" to the
+	filename before saving the NFT state.
+	@return mixed  state string or boolean false if unsuccessful
+	*/
+	public function save() {
+		$args = ['sub'=>'list ruleset', 'family'=>null, 'table'=>null];
+		$return = $this->exec($args);
+		if ($return === false) return false;
+		@rename($this->nft_statefile, $this->nft_statefile.'~');
+		if (file_put_contents($this->nft_statefile,implode(PHP_EOL, $return))
+			=== false) {
+			$this->log('('.$this->nft_statefile.')', [ 'Unable to write' ],
+				E_USER_WARNING);
+			return false;
+		}
+		return $return;
+	}
+	/*--------------------------------------------------------------------------
+	@param  array  $args NFT cli arguments eg ['sub'=>'list set','set'=>'jail']
+	@return mixed  NFT return string or boolean false if error status
+	*/
+	private function exec($args, $logerror = true) {
+		$exec_array = array_merge(self::NFT_SYNTAX,$args);
+		$exec_string = implode(' ',$exec_array);
+		$this->debug($exec_string);
+		exec($exec_string,$return,$status);
+		if ($status === 0) {
+			return $return;
+		} else {
+			if ($logerror) {
+				$this->log('('.$exec_array['sub'].')', $return, E_USER_WARNING);
+				$this->debug($exec_string);
+			}
+			return false;
+		}
+	}
+	/*--------------------------------------------------------------------------
+	@param  mixed $time string eg, "1d9h40m1s" integer 1200 or null
+	@return string  $time eg, "1d9h40m1s" or null or boolean false
+	*/
+	public function timestr($time) {
+		if (empty($time)) return $time;
+		if (is_numeric($time)) return $this->sec2str($time);
+		if ($this->str2sec($time) === false) {
+			return false;;
+		} else {
+			return $time;
+		}
+	}
+	/*--------------------------------------------------------------------------
+	@param  string $time eg, "1d9h40m1s"
+	@return mixed  $seconds int seconds or boolean false
+	*/
+	public function str2sec($time) {
+		if ($time === false || $time === null) return $time;
+		preg_match_all('/(\d+)([dhms])/',$time,$matches);
+		if (empty($matches[0])) return false;
+		$unitvalue = array_combine($matches[2],$matches[1]);
+		$seconds = 0;
+		foreach ($unitvalue as $unit => $value) {
+			$seconds += self::TIME_UNITS[$unit] * $value;
+		}
+		return $seconds;
+	}
+	/*--------------------------------------------------------------------------
+	@param  integer $seconds
+	@return string  $time eg, "1d9h40m1s"
+	*/
+	public function sec2str($seconds) {
+		if ($seconds === false || $seconds === null) return $seconds;
+		$time = "";
+		foreach (self::TIME_UNITS as $unit => $scale) {
+			$number = floor($seconds / $scale);
+			if ($number > 0) {
+				$time .= sprintf('%d%s',$number,$unit);
+				$seconds = $seconds % $scale;
+			}
+		}
+		return $time;
+	}
+	/*--------------------------------------------------------------------------
+	@param  string  $addr eg "23.94.144.50"
+	@return boolean
+	*/
+	public function is_addr($addr) {
+		if (ip2long($addr) === false) {
+			trigger_error(sprintf('Got invalid IP address (%s)',
+				$addr),E_USER_WARNING);
+			return false;
+		} else return true;
+	}
+	/*--------------------------------------------------------------------------
+	@param  mixed $time string eg, "1d9h40m1s"
+	@return boolean
+	*/
+	public function is_timestr($timeout) {
+		if ($this->timestr($timeout) === false) {
+			trigger_error(sprintf('Got invalid timeout value (%s)',
+				$timeout),E_USER_WARNING);
+			return false;
+		} else return true;
+	}
+	/*--------------------------------------------------------------------------
+	@param  string  $message eg "Jailing 23.94.144.50"
+	@param  mixed   $error eg 404
+	@param  integer $level eg E_USER_WARNING
+	@return void
+	*/
+	public function log($message, $error = [], $level = E_USER_NOTICE) {
+		if (isset($error[0])) {
+			$message = $message.' error: '.$error[0];
+		}
+		trigger_error($message, $level);
+	}
+	/*--------------------------------------------------------------------------
+	print table with headers: addr watch jail parole blacklist whitelist
+	@return void
+	*/
+	public function show() {
+		$db = [];
+		$id = self::SHOW_ID;
+		$headers = array_merge([$id],self::NFT_SETS);
+		$sets_num = count(self::NFT_SETS);
+		$form = "%15s".str_repeat("%13s", $sets_num)."\n";
+		foreach (self::NFT_SETS as $set) {
+			$elems = $this->list($set);
+			if (!empty($elems)) foreach ($elems as $addr => $time) {
+				$db_index = array_search($addr, array_column($db, $id));
+				if ($db_index === false) {
+					$db_index = -1 + array_push($db, array_merge([$id => $addr],
+						array_combine(self::NFT_SETS,
+						array_fill(0,$sets_num,null))));
+				}
+				$db[$db_index][$set] = $time;
+			}
+		}
+		usort($db, function($a,$b) use ($id) {
+			return ip2long($a[$id]) <=> ip2long($b[$id]);
+		});
+		$db_sums = array_map(function($head) use ($db) {
+			return count(array_filter(array_column($db, $head)));
+		}, $headers);
+		vprintf($form,$headers);
+		if (!empty($db)) foreach ($db as $elem) {
+				vprintf($form,array_values($elem));
+		}
+		vprintf($form,$db_sums);
+
+	}
+	/*--------------------------------------------------------------------------
+	Print variable if $debug or $this->debug is true
+	@param  mixed   $var
+	@param  boolean $debug
+	@return void
+	*/
+	public function debug($var, $debug = false) {
+		if($debug || $this->debug) {
+			var_dump($var);
+		}
+	}
+}
+?>


### PR DESCRIPTION
This experimental patch seeks to integrate **AutoBan** intrusion detection and prevention system
(c.f. https://github.com/mlan/docker-asterisk/tree/master/src/autoban, credits @mlan)
as a possibly more swift in response, yet also more lightweight alternative to Fail2Ban. 

AutoBan listens and responds directly to  [Asterisk AMI events]( https://wiki.asterisk.org/wiki/display/AST/Asterisk+20+AMI+Events) '**InvalidAccountID**', '**InvalidPassword**', '**ChallengeResponseFailed**' and '**FailedACL**' , a technically more straightforward  approach (compared to Fail2Ban) that is also employed by [**SecAst**(R)](https://telium.io/en/security-for-asterisk/technology/).

I have successfully build an according image which I am currently testing (_docker.io/hobbit00378/izpbx-asterisk:20.16.6_mwe_).
