### PR TITLE
Add Custom Script Hooks

### DIFF
--- a/izpbx-asterisk/rootfs/entrypoint-hooks.sh
+++ b/izpbx-asterisk/rootfs/entrypoint-hooks.sh
@@ -1736,4 +1736,32 @@ runHooks() {
   [[ "${HTTPD_HTTPS_ENABLED}" = "true" && "${LETSENCRYPT_ENABLED}" = "true" ]] && cfgService_letsencrypt
 }
 
+
+
+runCustomHooks() {
+
+  HOOK=${1:-""}
+  HOOKDIR=${APP_CUSTOM_SCRIPTS}/${HOOK}
+  
+  [ -z "${APP_CUSTOM_SCRIPTS}" ] && { echo "Custom Script Hooks : OFF ... SKIP script search" ; return ; }
+
+  echo "=> Looking for custom scripts ('${HOOK}' hook stage)"
+  echo "      in " '${APP_CUSTOM_SCRIPTS}/${HOOK}=' "'${HOOKDIR}'"
+  
+  if [ -d "${HOOKDIR}" ] ; then
+    for inc in ${HOOKDIR}/*.custom-inc ; do
+      if [ -r ${inc} ] ; then
+        echo "--> Found and source '${inc}' ..."
+        source ${inc}
+      fi
+    done 
+  fi
+
+}
+
+runCustomHooks pre-init
+
 runHooks
+
+runCustomHooks post-init
+


### PR DESCRIPTION
Commit adds a generic function 'runCustomHooks()' to izpbx-asterisk/rootfs/entrypoint-hooks.sh.
The function sources - depending on the value of envar APP_CUSTOM_SCRIPTS  -  additional script includes
from the  directory path stored in APP_CUSTOM_SCRIPTS if any.

This allows the user to further extend and customize izpbx by adding additional modules to the ROOTFS the initialization code for which then can be easly integrated and called via  runCustomHooks().

The advantage versus directly integrating and calling the initialization code for additional modules into izpbx-asterisk/rootfs/entrypoint-hooks.sh is that later changes of izpbx-asterisk/rootfs/entrypoint-hooks.sh made by the maintainer of this project won't easily break your code.

I use this function for initializing and starting the autoban module - a replacement for the fail2ban daemon (c.f. my branch 'autoban' for the corresponding code.
